### PR TITLE
Shrink kagome

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,7 +14,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  name = "github.com/ikawaha/kagome"
+  name = "github.com/ikawaha/kagome.ipadic"
   packages = [
     "internal/da",
     "internal/dic",
@@ -22,8 +22,8 @@
     "internal/lattice",
     "tokenizer"
   ]
-  revision = "a01f016539a1b763dfae43303e3ee45fc52db937"
-  version = "v1.7.1"
+  revision = "6a236696f3137ef6b532b20b6ae6b17be67cca07"
+  version = "v1.1.0"
 
 [[projects]]
   name = "github.com/mattn/go-sqlite3"

--- a/wakati/wakati.go
+++ b/wakati/wakati.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/YuheiNakasaka/sayhuuzoku/db"
 	"github.com/YuheiNakasaka/sayhuuzoku/scraping"
-	"github.com/ikawaha/kagome/tokenizer"
+	"github.com/ikawaha/kagome.ipadic/tokenizer"
 )
 
 // MyToken : token struct


### PR DESCRIPTION
Using kagome.ipadic instead of kagome, shrink disk image and download size.

```shellsession
-rwxr-xr-x  1 ikawaha  staff    26M  6 15 18:10 sayhuuzoku-shrink*
-rwxr-xr-x  1 ikawaha  staff    69M  6 15 18:02 /Users/ikawaha/go/bin/sayhuuzoku*
```

see. https://twitter.com/3socha/status/1139817589247377408?s=20